### PR TITLE
Introduce some infrastructure for undo/redo

### DIFF
--- a/src/main/java/seedu/address/commons/exceptions/CopyException.java
+++ b/src/main/java/seedu/address/commons/exceptions/CopyException.java
@@ -1,0 +1,18 @@
+package seedu.address.commons.exceptions;
+
+/**
+ * Represents an error during the copying of data
+ */
+public class CopyException extends Exception {
+    public CopyException(String message) {
+        super(message);
+    }
+
+    public CopyException(Throwable cause) {
+        super(cause);
+    }
+
+    public CopyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/seedu/address/commons/util/CopyUtil.java
+++ b/src/main/java/seedu/address/commons/util/CopyUtil.java
@@ -1,0 +1,27 @@
+package seedu.address.commons.util;
+
+import java.io.IOException;
+
+import seedu.address.commons.exceptions.CopyException;
+
+/**
+ * Deep copies an object
+ */
+public class CopyUtil {
+    /**
+     * Returns a deep copy of the specified object. The copy is performed by serializing the target object with a stream
+     * and then deserializing it.
+     *
+     * @param instance  the object to copy
+     * @param <T>  the generic type of the object to copy
+     * @return  the copied object
+     * @throws CopyException  if an error occurs while copying
+     */
+    public static <T> T deepCopy(T instance) throws CopyException {
+        try {
+            return (T) JsonUtil.fromJsonString(JsonUtil.toJsonString(instance), instance.getClass());
+        } catch (IOException e) {
+            throw new CopyException("Error copying object", e);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -14,7 +14,7 @@ import seedu.address.model.person.Person;
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends Command {
+public class AddCommand extends Command implements MutatorCommand {
 
     public static final String COMMAND_WORD = "add";
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -8,7 +8,7 @@ import seedu.address.model.Model;
 /**
  * Clears the address book.
  */
-public class ClearCommand extends Command {
+public class ClearCommand extends Command implements MutatorCommand {
 
     public static final String COMMAND_WORD = "clear";
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -13,7 +13,7 @@ import seedu.address.model.person.Person;
 /**
  * Deletes a person identified using it's displayed index from the address book.
  */
-public class DeleteCommand extends Command {
+public class DeleteCommand extends Command implements MutatorCommand {
 
     public static final String COMMAND_WORD = "delete";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -29,7 +29,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Edits the details of an existing person in the address book.
  */
-public class EditCommand extends Command {
+public class EditCommand extends Command implements MutatorCommand {
 
     public static final String COMMAND_WORD = "edit";
 

--- a/src/main/java/seedu/address/logic/commands/MutatorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MutatorCommand.java
@@ -1,0 +1,9 @@
+package seedu.address.logic.commands;
+
+/**
+ * Empty marker interface to indicate that a {@link Command} mutates the model. All data-modifying Commands should
+ * implement this interface.
+ */
+public interface MutatorCommand {
+
+}

--- a/src/test/java/seedu/address/commons/util/CopyUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/CopyUtilTest.java
@@ -1,0 +1,23 @@
+package seedu.address.commons.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.exceptions.CopyException;
+import seedu.address.testutil.SerializableTestClass;
+
+public class CopyUtilTest {
+
+    @Test
+    public void copyObject_noExceptionThrown() throws CopyException {
+        SerializableTestClass serializableTestClass = new SerializableTestClass();
+        serializableTestClass.setTestValues();
+
+        SerializableTestClass copy = CopyUtil.deepCopy(serializableTestClass);
+
+        assertEquals(serializableTestClass, copy);
+        assertNotSame(serializableTestClass, copy);
+    }
+}

--- a/src/test/java/seedu/address/testutil/SerializableTestClass.java
+++ b/src/test/java/seedu/address/testutil/SerializableTestClass.java
@@ -69,4 +69,15 @@ public class SerializableTestClass {
     public HashMap<Integer, String> getMapOfIntegerToString() {
         return mapOfIntegerToString;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SerializableTestClass)) {
+            return false;
+        }
+        SerializableTestClass s = (SerializableTestClass) o;
+        return this.name.equals(s.name)
+                && this.listOfLocalDateTimes.equals(s.listOfLocalDateTimes)
+                && this.mapOfIntegerToString.equals(s.mapOfIntegerToString);
+    }
 }


### PR DESCRIPTION
Introduce some infrastructure for undo/redo. Part of #59, #60 

- `CopyUtil` to do deep copying of the model so each model state can be saved.
- `MutatorCommand` marker interface to indicate a `Command` mutates the model. Moving forward, all Commands that modify `Model` data should implement this interface.